### PR TITLE
fix: returns (phi, theta, psi) as intrinsic ZYZ Euler angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![CI](https://github.com/teamtomo/torch-so3/actions/workflows/ci.yml/badge.svg)](https://github.com/teamtomo/torch-so3/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/teamtomo/torch-so3/branch/main/graph/badge.svg)](https://codecov.io/gh/teamtomo/torch-so3)
 
-Generate uniform 3D euler angles (ZYZ)
+Generate uniform sets of proper Euler angles (ZYZ format) over the SO(3) group using PyTorch.
+Note that Euler angles are returned in the order of $(\phi, \theta, \psi)$.
 
 ## Examples
 

--- a/src/torch_so3/uniform_so3_sampling.py
+++ b/src/torch_so3/uniform_so3_sampling.py
@@ -67,12 +67,17 @@ def get_uniform_euler_angles(
         phi_max=phi_max,
     )
 
+    # Change order of base_grid from (theta, phi) to (phi, theta)
+    base_grid = base_grid[:, [1, 0]]
+
     # Mesh-grid-like operation to include the in-plane rotation
     psi_all = torch.arange(psi_min, psi_max, in_plane_step, dtype=torch.float64)
 
     psi_mesh = psi_all.repeat_interleave(base_grid.size(0))
     base_grid = base_grid.repeat(psi_all.size(0), 1)
 
-    all_angles = torch.cat([psi_mesh[:, None], base_grid], dim=1)
+    # Ordering of angles is (phi, theta, psi) for ZYZ intrinsic rotations
+    # psi is the in-plane rotation
+    all_angles = torch.cat([base_grid, psi_mesh[:, None]], dim=1)
 
     return all_angles

--- a/tests/test_torch_angular_search.py
+++ b/tests/test_torch_angular_search.py
@@ -38,9 +38,9 @@ def test_get_local_high_resolution_angles():
     assert local_angles.shape == (63333, 3)
 
     # range tests for angles
-    assert np.allclose(local_angles[:, 0].min().item(), -1.5)
-    assert np.allclose(local_angles[:, 0].max().item(), 1.5)
+    assert (local_angles[:, 0] >= 0.0).all()
+    assert (local_angles[:, 0] < 360.0).all()
     assert (local_angles[:, 1] >= 0.0).all()
     assert (local_angles[:, 1] <= 2.5).all()
-    assert (local_angles[:, 2] >= 0.0).all()
-    assert (local_angles[:, 2] < 360.0).all()
+    assert np.allclose(local_angles[:, 2].min().item(), -1.5)
+    assert np.allclose(local_angles[:, 2].max().item(), 1.5)


### PR DESCRIPTION
Previously the Euler angles being returned were in the order $(\psi, \theta, \phi)$ which when run with downstream applications represented *extrinsic* Euler angles.

However, we want to conform to *intrinsic* Euler angles in the ZYZ format which requires the angles to be ordered as $(\phi, \theta, \psi)$. These represent a rotation of $\phi$ around the Z-axis, then a rotation of $\theta$ around the newly transformed Y'-axis and finally an in-plane rotation about the doubly transformed Z''-axis.

Pull request corrects this convention and and emphasizes this fact in the readme