### PR TITLE
Search over a given or all potenital roll axes

### DIFF
--- a/examples/generating_so3_angles.ipynb
+++ b/examples/generating_so3_angles.ipynb
@@ -34,8 +34,8 @@
    ],
    "source": [
     "angles = get_uniform_euler_angles(\n",
-    "    in_plane_step=1.5,\n",
-    "    out_of_plane_step=2.5,\n",
+    "    psi_step=1.5,\n",
+    "    theta_step=2.5,\n",
     "    phi_min=0.0,\n",
     "    phi_max=360.0,\n",
     "    theta_min=0.0,\n",

--- a/examples/visualizing_s2_grids.ipynb
+++ b/examples/visualizing_s2_grids.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Visualizing base S2 grids\n",
     "\n",
-    "The `torch-so3` package uses the [Hopf Fibration](https://en.wikipedia.org/wiki/Hopf_fibration) to generate Euler angles that sample the 3D rotation group SO(3) uniformly. We roughly follow the methods outline in the paper [Generating Uniform Incremental Grids on SO(3) Using the Hopf Fibration](https://doi.org/10.1177/0278364909352700) by Yershova et al. to generate these grids."
+    "The `torch-so3` package uses the uniform sampling to generate Euler angles that sample the 3D rotation group SO(3) uniformly."
    ]
   },
   {
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out_of_plane_step = 2.5"
+    "theta_step = 2.5"
    ]
   },
   {
@@ -87,7 +87,7 @@
     }
    ],
    "source": [
-    "theta_phi_pairs_uniform = uniform_base_grid(out_of_plane_step)\n",
+    "theta_phi_pairs_uniform = uniform_base_grid(theta_step)\n",
     "print(\"Total points (uniform):\", theta_phi_pairs_uniform.shape[0])"
    ]
   },
@@ -105,7 +105,7 @@
     }
    ],
    "source": [
-    "theta_phi_pairs_healpix = healpix_base_grid(out_of_plane_step)\n",
+    "theta_phi_pairs_healpix = healpix_base_grid(theta_step)\n",
     "print(\"Total points (healpix):\", theta_phi_pairs_healpix.shape[0])"
    ]
   },

--- a/examples/visualizing_s2_grids.ipynb
+++ b/examples/visualizing_s2_grids.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Visualizing base S2 grids\n",
     "\n",
-    "The `torch-so3` package uses the uniform sampling to generate Euler angles that sample the 3D rotation group SO(3) uniformly."
+    "The `torch-so3` package implements uniform sampling techniques to generate Euler angles that sample the 3D rotation group SO(3) uniformly."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     "torch", 
     "numpy", 
-    "healpy==1.18.0; platform_system != 'Windows'"
+    "healpy; platform_system != 'Windows'"
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 # add your package dependencies here
-dependencies = ["torch", "numpy", "healpy; platform_system != 'Windows'"]
+dependencies = ["torch>=2.6.0", "numpy", "healpy; platform_system != 'Windows'"]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 # "extras" (e.g. for `pip install .[test]`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ classifiers = [
     "Typing :: Typed",
 ]
 # add your package dependencies here
-dependencies = ["torch>=2.6.0", "numpy", "healpy; platform_system != 'Windows'"]
+dependencies = [
+    "torch", 
+    "numpy", 
+    "healpy==1.18.0; platform_system != 'Windows'"
+]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 # "extras" (e.g. for `pip install .[test]`)

--- a/src/torch_so3/__init__.py
+++ b/src/torch_so3/__init__.py
@@ -11,10 +11,6 @@ __email__ = "jdickerson@berkeley.edu"
 
 from .local_so3_sampling import get_local_high_resolution_angles
 from .uniform_so3_sampling import get_uniform_euler_angles
-
-__all__ = ["get_uniform_euler_angles", "get_local_high_resolution_angles"]
-
-# Import all modules and functions
 from .angular_ranges import SymmetryRanges, get_symmetry_ranges
 from .base_s2_grid import cartesian_base_grid, healpix_base_grid, uniform_base_grid
 

--- a/src/torch_so3/__init__.py
+++ b/src/torch_so3/__init__.py
@@ -13,3 +13,17 @@ from .local_so3_sampling import get_local_high_resolution_angles
 from .uniform_so3_sampling import get_uniform_euler_angles
 
 __all__ = ["get_uniform_euler_angles", "get_local_high_resolution_angles"]
+
+# Import all modules and functions
+from .angular_ranges import SymmetryRanges, get_symmetry_ranges
+from .base_s2_grid import cartesian_base_grid, healpix_base_grid, uniform_base_grid
+
+__all__ = [
+    "get_uniform_euler_angles",
+    "get_local_high_resolution_angles",
+    "get_symmetry_ranges",
+    "SymmetryRanges",
+    "uniform_base_grid",
+    "healpix_base_grid",
+    "cartesian_base_grid",
+]

--- a/src/torch_so3/__init__.py
+++ b/src/torch_so3/__init__.py
@@ -9,14 +9,10 @@ except PackageNotFoundError:
 __author__ = "Josh Dickerson"
 __email__ = "jdickerson@berkeley.edu"
 
-from .local_so3_sampling import get_local_high_resolution_angles
-from .uniform_so3_sampling import get_uniform_euler_angles
-
-__all__ = ["get_uniform_euler_angles", "get_local_high_resolution_angles"]
-
-# Import all modules and functions
 from .angular_ranges import SymmetryRanges, get_symmetry_ranges
 from .base_s2_grid import cartesian_base_grid, healpix_base_grid, uniform_base_grid
+from .local_so3_sampling import get_local_high_resolution_angles
+from .uniform_so3_sampling import get_uniform_euler_angles
 
 __all__ = [
     "get_uniform_euler_angles",

--- a/src/torch_so3/__init__.py
+++ b/src/torch_so3/__init__.py
@@ -9,15 +9,15 @@ except PackageNotFoundError:
 __author__ = "Josh Dickerson"
 __email__ = "jdickerson@berkeley.edu"
 
-from .local_so3_sampling import get_local_high_resolution_angles
-from .uniform_so3_sampling import get_uniform_euler_angles
 from .angular_ranges import SymmetryRanges, get_symmetry_ranges
 from .base_s2_grid import cartesian_base_grid, healpix_base_grid, uniform_base_grid
-
+from .local_so3_sampling import get_local_high_resolution_angles, get_roll_angles
+from .uniform_so3_sampling import get_uniform_euler_angles
 
 __all__ = [
     "get_uniform_euler_angles",
     "get_local_high_resolution_angles",
+    "get_roll_angles",
     "get_symmetry_ranges",
     "SymmetryRanges",
     "uniform_base_grid",

--- a/src/torch_so3/__init__.py
+++ b/src/torch_so3/__init__.py
@@ -9,10 +9,15 @@ except PackageNotFoundError:
 __author__ = "Josh Dickerson"
 __email__ = "jdickerson@berkeley.edu"
 
-from .angular_ranges import SymmetryRanges, get_symmetry_ranges
-from .base_s2_grid import cartesian_base_grid, healpix_base_grid, uniform_base_grid
 from .local_so3_sampling import get_local_high_resolution_angles
 from .uniform_so3_sampling import get_uniform_euler_angles
+
+__all__ = ["get_uniform_euler_angles", "get_local_high_resolution_angles"]
+
+# Import all modules and functions
+from .angular_ranges import SymmetryRanges, get_symmetry_ranges
+from .base_s2_grid import cartesian_base_grid, healpix_base_grid, uniform_base_grid
+
 
 __all__ = [
     "get_uniform_euler_angles",

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -163,7 +163,7 @@ def healpix_base_grid(
     return angle_pairs
 
 
-def basic_base_grid(
+def cartesian_base_grid(
     out_of_plane_step: float = 2.5,
     in_plane_step: float = 1.5,
     theta_min: float = 0.0,
@@ -171,7 +171,7 @@ def basic_base_grid(
     phi_min: float = 0.0,
     phi_max: float = 360.0,
 ) -> torch.Tensor:
-    """Generate a base grid on the S^2 sphere using a basic grid.
+    """Generate a base grid on the S^2 sphere using a cartesian grid.
 
     Parameters
     ----------

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -3,12 +3,12 @@
 import platform
 import warnings
 
+import numpy as np
+import torch
 if platform.system() == "Windows":
     warnings.warn("healpy cannot be installed on Windows systems.", stacklevel=2)
 else:
     import healpy as hp
-import numpy as np
-import torch
 
 
 def uniform_base_grid(

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -20,6 +20,9 @@ def uniform_base_grid(
 ) -> torch.Tensor:
     """Generate a uniform base grid on the S^2 sphere.
 
+    phi step is calculated by the position on the sphere (sin(theta))
+
+
     Parameters
     ----------
     theta_step : float, optional
@@ -83,6 +86,8 @@ def healpix_base_grid(
     phi_max: float = 360.0,
 ) -> torch.Tensor:
     """Generate a base grid on the S^2 sphere using HEALPix.
+
+    phi step is calculated by the position on the sphere
 
     Parameters
     ----------
@@ -164,6 +169,8 @@ def cartesian_base_grid(
     phi_max: float = 360.0,
 ) -> torch.Tensor:
     """Generate a base grid on the S^2 sphere using a cartesian grid.
+
+    phi step is now set explicitly. This will oversample the poles.
 
     Parameters
     ----------

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -68,7 +68,6 @@ def uniform_base_grid(
         if phi_min_rad >= phi_max_rad or phi_step <= 0.0:
             phi_values = np.array([phi_min_rad], dtype=np.float64)
         else:
-            print(phi_min_rad, phi_max_rad, phi_step)
             phi_values = np.arange(phi_min_rad, phi_max_rad, phi_step, dtype=np.float64)
         theta_values = np.full_like(phi_values, theta_all[i])
         angle_pairs.append(np.stack([phi_values, theta_values], axis=1))

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -12,7 +12,7 @@ import torch
 
 
 def uniform_base_grid(
-    out_of_plane_step: float = 2.5,
+    theta_step: float = 2.5,
     theta_min: float = 0.0,
     theta_max: float = 180.0,
     phi_min: float = 0.0,
@@ -22,9 +22,7 @@ def uniform_base_grid(
 
     Parameters
     ----------
-    in_plane_step : float, optional
-        Angular step for in-plane rotation (phi) in degrees. Default is 1.5 degrees.
-    out_of_plane_step : float, optional
+    theta_step : float, optional
         Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
         degrees.
     theta_min : float, optional
@@ -42,20 +40,20 @@ def uniform_base_grid(
         Tensor of shape (N, 2) containing theta and phi values in degrees, where N is
         the number of angles pairs generated.
     """
-    out_of_plane_step_rad = np.deg2rad(out_of_plane_step)
+    theta_step_rad = np.deg2rad(theta_step)
     phi_min_rad = np.deg2rad(phi_min)
     phi_max_rad = np.deg2rad(phi_max)
 
     # generate uniform set of theta values
     theta_all = np.arange(
-        theta_min, theta_max + out_of_plane_step, out_of_plane_step, dtype=np.float64
+        theta_min, theta_max + theta_step, theta_step, dtype=np.float64
     )
     theta_all = np.deg2rad(theta_all)
 
     # Phi step increment is modulated by the position on the sphere (sin(theta)), but
     # don't allow it to exceed the maximum step size
     phi_max_step_rad = phi_max_rad - phi_min_rad
-    phi_step_all = np.abs(out_of_plane_step_rad / (np.sin(theta_all) + 1e-6))
+    phi_step_all = np.abs(theta_step_rad / (np.sin(theta_all) + 1e-6))
     phi_step_all = np.clip(phi_step_all, a_min=None, a_max=phi_max_step_rad)
     if phi_max_step_rad > 0.0:
         phi_step_all = phi_max_step_rad / np.round(phi_max_step_rad / phi_step_all)
@@ -79,7 +77,7 @@ def uniform_base_grid(
 
 
 def healpix_base_grid(
-    out_of_plane_step: float = 2.5,
+    theta_step: float = 2.5,
     theta_min: float = 0.0,
     theta_max: float = 180.0,
     phi_min: float = 0.0,
@@ -89,9 +87,7 @@ def healpix_base_grid(
 
     Parameters
     ----------
-    in_plane_step : float, optional
-        Angular step for in-plane rotation (phi) in degrees. Default is 1.5 degrees.
-    out_of_plane_step : float, optional
+    theta_step : float, optional
         Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
         degrees.
     theta_min : float, optional
@@ -112,11 +108,9 @@ def healpix_base_grid(
     if platform.system() == "Windows":
         raise ImportError("healpy cannot be installed on Windows systems.")
 
-    out_of_plane_step_rad = np.deg2rad(out_of_plane_step)
+    theta_step_rad = np.deg2rad(theta_step)
 
-    estimated_num_pixels = int(
-        4 * np.pi / (out_of_plane_step_rad * out_of_plane_step_rad)
-    )
+    estimated_num_pixels = int(4 * np.pi / (theta_step_rad * theta_step_rad))
 
     # Find the next largest npix value for a valid healpix grid
     exact_num_pixels = 0
@@ -164,8 +158,8 @@ def healpix_base_grid(
 
 
 def cartesian_base_grid(
-    out_of_plane_step: float = 2.5,
-    in_plane_step: float = 1.5,
+    theta_step: float = 2.5,
+    phi_step: float = 1.5,
     theta_min: float = 0.0,
     theta_max: float = 180.0,
     phi_min: float = 0.0,
@@ -175,10 +169,10 @@ def cartesian_base_grid(
 
     Parameters
     ----------
-    out_of_plane_step : float, optional
+    theta_step : float, optional
         Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
         degrees.
-    in_plane_step : float, optional
+    phi_step : float, optional
         Angular step for in-plane rotation (phi) in degrees. Default is 1.5 degrees.
     theta_min : float, optional
         Minimum value for theta in degrees. Default is 0.0.
@@ -199,14 +193,14 @@ def cartesian_base_grid(
     phi_values = torch.arange(
         phi_min,
         phi_max,
-        in_plane_step,
+        phi_step,
         dtype=torch.float64,
     )
 
     theta_values = torch.arange(
         theta_min,
         theta_max,
-        out_of_plane_step,
+        theta_step,
         dtype=torch.float64,
     )
 

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -23,8 +23,7 @@ def uniform_base_grid(
     Parameters
     ----------
     theta_step : float, optional
-        Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
-        degrees.
+        Angular step for theta in degrees. Default is 2.5
     theta_min : float, optional
         Minimum value for theta in degrees. Default is 0.0.
     theta_max : float, optional
@@ -88,8 +87,7 @@ def healpix_base_grid(
     Parameters
     ----------
     theta_step : float, optional
-        Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
-        degrees.
+        Angular step for theta in degrees. Default is 2.5
     theta_min : float, optional
         Minimum value for theta in degrees. Default is 0.0.
     theta_max : float, optional
@@ -170,10 +168,9 @@ def cartesian_base_grid(
     Parameters
     ----------
     theta_step : float, optional
-        Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
-        degrees.
+        Angular step for theta in degrees. Default is 2.5
     phi_step : float, optional
-        Angular step for in-plane rotation (phi) in degrees. Default is 1.5 degrees.
+        Angular step for phi in degrees. Default is 1.5 degrees.
     theta_min : float, optional
         Minimum value for theta in degrees. Default is 0.0.
     theta_max : float, optional

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -62,7 +62,10 @@ def uniform_base_grid(
     # Now generate the angle pairs
     angle_pairs = []
     for i, phi_step in enumerate(phi_step_all):
-        phi_values = np.arange(phi_min_rad, phi_max_rad, phi_step, dtype=np.float64)
+        if phi_min_rad > phi_max_rad or phi_step <= 0.0:
+            phi_values = np.array([phi_min_rad], dtype=np.float64)
+        else:
+            phi_values = np.arange(phi_min_rad, phi_max_rad, phi_step, dtype=np.float64)
         theta_values = np.full_like(phi_values, theta_all[i])
         angle_pairs.append(np.stack([phi_values, theta_values], axis=1))
 

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -64,7 +64,7 @@ def uniform_base_grid(
     for i, phi_step in enumerate(phi_step_all):
         phi_values = np.arange(phi_min_rad, phi_max_rad, phi_step, dtype=np.float64)
         theta_values = np.full_like(phi_values, theta_all[i])
-        angle_pairs.append(np.stack([theta_values, phi_values], axis=1))
+        angle_pairs.append(np.stack([phi_values, theta_values], axis=1))
 
     # Convert back to degrees
     angle_pairs = np.rad2deg(np.concatenate(angle_pairs))
@@ -152,6 +152,59 @@ def healpix_base_grid(
         theta_values = torch.cat(theta_result)
         phi_values = torch.cat(phi_result)
 
-    angle_pairs = torch.stack([theta_values, phi_values], dim=1)
+    angle_pairs = torch.stack([phi_values, theta_values], dim=1)
 
     return angle_pairs
+
+
+def basic_base_grid(
+    out_of_plane_step: float = 2.5,
+    in_plane_step: float = 1.5,
+    theta_min: float = 0.0,
+    theta_max: float = 180.0,
+    phi_min: float = 0.0,
+    phi_max: float = 360.0,
+) -> torch.Tensor:
+    """Generate a base grid on the S^2 sphere using a basic grid.
+
+    Parameters
+    ----------
+    out_of_plane_step : float, optional
+        Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
+        degrees.
+    in_plane_step : float, optional
+        Angular step for in-plane rotation (phi) in degrees. Default is 1.5 degrees.
+    theta_min : float, optional
+        Minimum value for theta in degrees. Default is 0.0.
+    theta_max : float, optional
+        Maximum value for theta in degrees. Default is 180.0.
+    phi_min : float, optional
+        Minimum value for phi in degrees. Default is 0.0.
+    phi_max : float, optional
+        Maximum value for phi in degrees. Default is 360.0.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape (N, 2) containing theta and phi values in degrees, where N is
+        the number of angles pairs generated.
+    """
+    # Generate the base grid
+    phi_values = torch.arange(
+        phi_min,
+        phi_max,
+        in_plane_step,
+        dtype=torch.float64,
+    )
+
+    theta_values = torch.arange(
+        theta_min,
+        theta_max,
+        out_of_plane_step,
+        dtype=torch.float64,
+    )
+
+    grid = torch.meshgrid(phi_values, theta_values, indexing="ij")
+    euler_angles = torch.stack(grid, dim=-1).reshape(-1, 2)
+
+    return euler_angles

--- a/src/torch_so3/base_s2_grid.py
+++ b/src/torch_so3/base_s2_grid.py
@@ -57,14 +57,18 @@ def uniform_base_grid(
     phi_max_step_rad = phi_max_rad - phi_min_rad
     phi_step_all = np.abs(out_of_plane_step_rad / (np.sin(theta_all) + 1e-6))
     phi_step_all = np.clip(phi_step_all, a_min=None, a_max=phi_max_step_rad)
-    phi_step_all = phi_max_step_rad / np.round(phi_max_step_rad / phi_step_all)
+    if phi_max_step_rad > 0.0:
+        phi_step_all = phi_max_step_rad / np.round(phi_max_step_rad / phi_step_all)
+    else:
+        phi_step_all *= 0.0
 
     # Now generate the angle pairs
     angle_pairs = []
     for i, phi_step in enumerate(phi_step_all):
-        if phi_min_rad > phi_max_rad or phi_step <= 0.0:
+        if phi_min_rad >= phi_max_rad or phi_step <= 0.0:
             phi_values = np.array([phi_min_rad], dtype=np.float64)
         else:
+            print(phi_min_rad, phi_max_rad, phi_step)
             phi_values = np.arange(phi_min_rad, phi_max_rad, phi_step, dtype=np.float64)
         theta_values = np.full_like(phi_values, theta_all[i])
         angle_pairs.append(np.stack([phi_values, theta_values], axis=1))

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -10,10 +10,12 @@ EPS = 1e-6
 
 
 def get_local_high_resolution_angles(
-    coarse_in_plane_step: float = 1.5,
-    coarse_out_of_plane_step: float = 2.5,
-    fine_in_plane_step: float = 0.1,
-    fine_out_of_plane_step: float = 0.1,
+    coarse_psi_step: float = 1.5,
+    coarse_theta_step: float = 2.5,
+    coarse_phi_step: float = 2.5,
+    fine_psi_step: float = 0.1,
+    fine_theta_step: float = 0.1,
+    fine_phi_step: float = 0.1,
     base_grid_method: Literal["uniform", "healpix", "cartesian"] = "uniform",
 ) -> torch.Tensor:
     """Local orientation refinement from a coarse to fine grid.
@@ -24,14 +26,18 @@ def get_local_high_resolution_angles(
 
     Parameters
     ----------
-    coarse_in_plane_step : float
-        Coarse step size for in-plane angle (psi) in degrees.
-    coarse_out_of_plane_step : float
-        Coarse step size for out-of-plane angle (theta, phi) in degrees.
-    fine_in_plane_step : float
-        Finer step size for in-plane angles (psi) in degrees.
-    fine_out_of_plane_step : float
-        Finer step size for out-of-plane angle (theta, phi) in degrees.
+    coarse_psi_step : float
+        Coarse step size for psi in degrees.
+    coarse_theta_step : float
+        Coarse step size for theta in degrees.
+    coarse_phi_step : float
+        Coarse step size for phi in degrees.
+    fine_psi_step : float
+        Finer step size for psi in degrees.
+    fine_theta_step : float
+        Finer step size for theta in degrees.
+    fine_phi_step : float
+        Finer step size for phi in degrees.
     base_grid_method : Literal["uniform", "healpix", "cartesian"]
         Method to generate the base grid.
 
@@ -42,16 +48,30 @@ def get_local_high_resolution_angles(
         number of angles generated. Angles exist around pole (0, 0, 0) and define grid
         to search over.
     """
-    euler_angles = get_uniform_euler_angles(
-        in_plane_step=fine_in_plane_step,
-        out_of_plane_step=fine_out_of_plane_step,
-        phi_min=-coarse_in_plane_step,  # Completely sample for uniform base grid?
-        phi_max=coarse_in_plane_step,
-        theta_min=-coarse_out_of_plane_step,
-        theta_max=coarse_out_of_plane_step,
-        psi_min=-coarse_in_plane_step,
-        psi_max=coarse_in_plane_step + EPS,
-        base_grid_method=base_grid_method,
-    )
+    if base_grid_method == "cartesian":
+        euler_angles = get_uniform_euler_angles(
+            psi_step=fine_psi_step,
+            theta_step=fine_theta_step,
+            phi_step=fine_phi_step,
+            phi_min=-coarse_phi_step,  # Completely sample for uniform base grid?
+            phi_max=coarse_phi_step,
+            theta_min=-coarse_theta_step,
+            theta_max=coarse_theta_step,
+            psi_min=-coarse_psi_step,
+            psi_max=coarse_psi_step + EPS,
+            base_grid_method=base_grid_method,
+        )
+    else:
+        euler_angles = get_uniform_euler_angles(
+            psi_step=fine_psi_step,
+            theta_step=fine_theta_step,
+            phi_min=-coarse_psi_step,  # Completely sample for uniform base grid?
+            phi_max=coarse_psi_step,
+            theta_min=-coarse_theta_step,
+            theta_max=coarse_theta_step,
+            psi_min=-coarse_psi_step,
+            psi_max=coarse_psi_step + EPS,
+            base_grid_method=base_grid_method,
+        )
 
     return euler_angles

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -1,5 +1,7 @@
 """Generate finer angular search around multiple selected Euler angles."""
 
+from typing import Literal
+
 import torch
 
 from torch_so3.uniform_so3_sampling import get_uniform_euler_angles
@@ -12,6 +14,7 @@ def get_local_high_resolution_angles(
     coarse_out_of_plane_step: float = 2.5,
     fine_in_plane_step: float = 0.1,
     fine_out_of_plane_step: float = 0.1,
+    base_grid_method: Literal["uniform", "healpix", "basic"] = "uniform",
 ) -> torch.Tensor:
     """Local orientation refinement from a coarse to fine grid.
 
@@ -29,6 +32,8 @@ def get_local_high_resolution_angles(
         Finer step size for in-plane angles (psi) in degrees.
     fine_out_of_plane_step : float
         Finer step size for out-of-plane angle (theta, phi) in degrees.
+    base_grid_method : Literal["uniform", "healpix", "basic"]
+        Method to generate the base grid.
 
     Returns
     -------
@@ -40,12 +45,13 @@ def get_local_high_resolution_angles(
     euler_angles = get_uniform_euler_angles(
         in_plane_step=fine_in_plane_step,
         out_of_plane_step=fine_out_of_plane_step,
+        phi_min=-coarse_in_plane_step,  # Completely sample for uniform base grid?
+        phi_max=coarse_in_plane_step,
+        theta_min=-coarse_out_of_plane_step,
+        theta_max=coarse_out_of_plane_step,
         psi_min=-coarse_in_plane_step,
         psi_max=coarse_in_plane_step + EPS,
-        theta_min=0.0,
-        theta_max=coarse_out_of_plane_step,
-        phi_min=0.0,  # Completely sample around the s2 sphere
-        phi_max=360.0,
+        base_grid_method=base_grid_method,
     )
 
     return euler_angles

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -153,7 +153,7 @@ def get_roll_angles(
     theta_flat = theta_grid.reshape(-1)
     psi_flat = psi_grid.reshape(-1)
 
-    # For each combination ( I do extrinsic in my head so go backwards):
+    # For each combination (I do extrinsic in my head so go backwards):
     # 1. First Euler angle (phi): Rotate to align back with the psi_angle
     # 2. Second Euler angle (theta): Apply theta rotation around roll axis
     # 3. Third Euler angle (psi): Rotate to align with roll axis

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -26,12 +26,12 @@ def get_local_high_resolution_angles(
 
     Parameters
     ----------
-    coarse_psi_step : float
-        Coarse step size for psi in degrees.
-    coarse_theta_step : float
-        Coarse step size for theta in degrees.
     coarse_phi_step : float
         Coarse step size for phi in degrees.
+    coarse_theta_step : float
+        Coarse step size for theta in degrees.
+    coarse_psi_step : float
+        Coarse step size for psi in degrees.
     fine_psi_step : float
         Finer step size for psi in degrees.
     fine_theta_step : float
@@ -50,9 +50,9 @@ def get_local_high_resolution_angles(
     """
     if base_grid_method == "cartesian":
         euler_angles = get_uniform_euler_angles(
-            psi_step=fine_psi_step,
-            theta_step=fine_theta_step,
             phi_step=fine_phi_step,
+            theta_step=fine_theta_step,
+            psi_step=fine_psi_step,
             phi_min=-coarse_phi_step,  # Completely sample for uniform base grid?
             phi_max=coarse_phi_step,
             theta_min=-coarse_theta_step,

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -14,7 +14,7 @@ def get_local_high_resolution_angles(
     coarse_out_of_plane_step: float = 2.5,
     fine_in_plane_step: float = 0.1,
     fine_out_of_plane_step: float = 0.1,
-    base_grid_method: Literal["uniform", "healpix", "basic"] = "uniform",
+    base_grid_method: Literal["uniform", "healpix", "cartesian"] = "uniform",
 ) -> torch.Tensor:
     """Local orientation refinement from a coarse to fine grid.
 
@@ -32,7 +32,7 @@ def get_local_high_resolution_angles(
         Finer step size for in-plane angles (psi) in degrees.
     fine_out_of_plane_step : float
         Finer step size for out-of-plane angle (theta, phi) in degrees.
-    base_grid_method : Literal["uniform", "healpix", "basic"]
+    base_grid_method : Literal["uniform", "healpix", "cartesian"]
         Method to generate the base grid.
 
     Returns

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -75,3 +75,103 @@ def get_local_high_resolution_angles(
         )
 
     return euler_angles
+
+
+def get_roll_angles(
+    psi_step: float = 0.5,
+    psi_min: float = -10.0,
+    psi_max: float = 10.0,
+    theta_step: float = 0.5,
+    theta_min: float = -10.0,
+    theta_max: float = 10.0,
+    roll_axis: torch.Tensor = None,
+    roll_axis_step: float = 2.0,
+) -> torch.Tensor:
+    """Generate a grid of Euler angles for rotations around Z and a roll axis.
+
+    This function generates ZYZ Euler angles (in degrees) that represent:
+    1. Rotations around the Z axis (primary rotation)
+    2. Rotations around a "roll axis" that's in the XY plane
+       (orthogonal to Z but not necessarily aligned with Y)
+
+    If no specific roll axis is provided, it samples multiple possible roll axes
+    by varying angles in the XY plane and using complementary rotations that
+    sum to the desired psi angle.
+
+    Parameters
+    ----------
+    psi_step : float, optional
+        Step size for the in-plane rotation (psi) in degrees, by default 0.5
+    psi_min : float, optional
+        Minimum value for psi in degrees, by default -10.0
+    psi_max : float, optional
+        Maximum value for psi in degrees, by default 10.0
+    theta_step : float, optional
+        Step size for the roll rotation (theta) in degrees, by default 0.5
+    theta_min : float, optional
+        Minimum value for theta in degrees, by default -10.0
+    theta_max : float, optional
+        Maximum value for theta in degrees, by default 10.0
+    roll_axis : torch.Tensor, optional
+        If provided, specifies a fixed roll axis as [x, y] in Cartesian coordinates.
+        If None, searches through multiple roll axes, by default None.
+    roll_axis_step : float, optional
+        Angular step for searching different roll axes in degrees, by default 2.0
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape (N, 3) containing Euler angles (phi, theta, psi) in degrees
+        representing the sampled rotations.
+    """
+    # Generate arrays for psi (rotation around Z) and theta (roll angle)
+    psi_values = torch.arange(psi_min, psi_max + EPS, psi_step, dtype=torch.float32)
+    theta_values = torch.arange(
+        theta_min, theta_max + EPS, theta_step, dtype=torch.float32
+    )
+
+    # Set up the roll axis search
+    if roll_axis is None:
+        # Search for roll axes by sampling angles in the XY plane
+        roll_angles = torch.arange(0, 180, roll_axis_step, dtype=torch.float32)
+    else:
+        # Use the given roll axis [x,y] to determine the roll angle
+        # Convert from Cartesian coordinates to angle in the XY plane
+        roll_angle = torch.rad2deg(torch.atan2(roll_axis[1], roll_axis[0]))
+        # Normalize to 0-180 range
+        if roll_angle < 0:
+            roll_angle += 180
+        roll_angles = torch.tensor([roll_angle], dtype=torch.float32)
+
+    # Create meshgrid for all dimensions
+    roll_grid, theta_grid, psi_grid = torch.meshgrid(
+        roll_angles, theta_values, psi_values, indexing="ij"
+    )
+
+    # Flatten all grids
+    roll_flat = roll_grid.reshape(-1)
+    theta_flat = theta_grid.reshape(-1)
+    psi_flat = psi_grid.reshape(-1)
+
+    # For each combination ( I do extrinsic in my head so go backwards):
+    # 1. First Euler angle (phi): Rotate to align back with the psi_angle
+    # 2. Second Euler angle (theta): Apply theta rotation around roll axis
+    # 3. Third Euler angle (psi): Rotate to align with roll axis
+
+    # Second Euler angle: theta rotation around roll axis
+    theta = theta_flat
+
+    # Third Euler angle: rotate back to achieve the desired psi rotation
+    # We rotate back by (roll_angle - psi_value) to get a net psi rotation
+    psi = 360 - roll_flat
+
+    # Adjust back-rotation to achieve desired rotation axis angle
+    phi = roll_flat + psi_flat
+
+    # Ensure phi is within [0, 360) range
+    phi = phi % 360
+
+    # Stack the Euler angles
+    all_angles = torch.stack([phi, theta, psi], dim=1)
+
+    return all_angles

--- a/src/torch_so3/local_so3_sampling.py
+++ b/src/torch_so3/local_so3_sampling.py
@@ -10,12 +10,12 @@ EPS = 1e-6
 
 
 def get_local_high_resolution_angles(
-    coarse_psi_step: float = 1.5,
-    coarse_theta_step: float = 2.5,
     coarse_phi_step: float = 2.5,
-    fine_psi_step: float = 0.1,
-    fine_theta_step: float = 0.1,
+    coarse_theta_step: float = 2.5,
+    coarse_psi_step: float = 1.5,
     fine_phi_step: float = 0.1,
+    fine_theta_step: float = 0.1,
+    fine_psi_step: float = 0.1,
     base_grid_method: Literal["uniform", "healpix", "cartesian"] = "uniform",
 ) -> torch.Tensor:
     """Local orientation refinement from a coarse to fine grid.
@@ -32,12 +32,12 @@ def get_local_high_resolution_angles(
         Coarse step size for theta in degrees.
     coarse_psi_step : float
         Coarse step size for psi in degrees.
-    fine_psi_step : float
-        Finer step size for psi in degrees.
-    fine_theta_step : float
-        Finer step size for theta in degrees.
     fine_phi_step : float
         Finer step size for phi in degrees.
+    fine_theta_step : float
+        Finer step size for theta in degrees.
+    fine_psi_step : float
+        Finer step size for psi in degrees.
     base_grid_method : Literal["uniform", "healpix", "cartesian"]
         Method to generate the base grid.
 

--- a/src/torch_so3/uniform_so3_sampling.py
+++ b/src/torch_so3/uniform_so3_sampling.py
@@ -5,7 +5,7 @@ from typing import Literal
 import torch
 
 from torch_so3.base_s2_grid import (
-    basic_base_grid,
+    cartesian_base_grid,
     healpix_base_grid,
     uniform_base_grid,
 )
@@ -20,7 +20,7 @@ def get_uniform_euler_angles(
     theta_max: float = 180.0,
     psi_min: float = 0.0,
     psi_max: float = 360.0,
-    base_grid_method: Literal["uniform", "healpix", "basic"] = "uniform",
+    base_grid_method: Literal["uniform", "healpix", "cartesian"] = "uniform",
 ) -> torch.Tensor:
     """Generate sets of uniform Euler angles (ZYZ) using Hopf fibration.
 
@@ -45,7 +45,7 @@ def get_uniform_euler_angles(
         Maximum value for psi in degrees. Default is 360.0.
     base_grid_method: str, optional
         String literal specifying the method to generate the base grid. Default is
-        "uniform". Options are "uniform", "healpix", and "basic".
+        "uniform". Options are "uniform", "healpix", and "cartesian".
 
     Returns
     -------
@@ -55,9 +55,9 @@ def get_uniform_euler_angles(
     """
     # TODO: Validation of inputs, wrapping between zero and 2*pi, etc.
 
-    if base_grid_method == "basic":
+    if base_grid_method == "cartesian":
         # Handle basic_base_grid separately since it has a different signature
-        base_grid = basic_base_grid(
+        base_grid = cartesian_base_grid(
             out_of_plane_step=out_of_plane_step,
             in_plane_step=in_plane_step,
             theta_min=theta_min,

--- a/src/torch_so3/uniform_so3_sampling.py
+++ b/src/torch_so3/uniform_so3_sampling.py
@@ -29,9 +29,9 @@ def get_uniform_euler_angles(
     Parameters
     ----------
     psi_step: float, optional
-        Angular step for in-plane rotation (psi) in degrees. Default is 1.5 degrees.
+        Angular step for psi in degrees. Default is 1.5 degrees.
     theta_step: float, optional
-        Angular step for out-of-plane rotation (theta) in degrees. Default is 2.5
+        Angular step for theta in degrees. Default is 2.5
         degrees.
     phi_step: float, optional
         Angular step for phi rotation in degrees. Only used when base_grid_method is

--- a/src/torch_so3/uniform_so3_sampling.py
+++ b/src/torch_so3/uniform_so3_sampling.py
@@ -83,7 +83,10 @@ def get_uniform_euler_angles(
         )
 
     # Mesh-grid-like operation to include the in-plane rotation
-    psi_all = torch.arange(psi_min, psi_max, in_plane_step, dtype=torch.float64)
+    if psi_min >= psi_max:
+        psi_all = torch.tensor([psi_min], dtype=torch.float64)
+    else:
+        psi_all = torch.arange(psi_min, psi_max, in_plane_step, dtype=torch.float64)
 
     psi_mesh = psi_all.repeat_interleave(base_grid.size(0))
     base_grid = base_grid.repeat(psi_all.size(0), 1)

--- a/tests/test_torch_angular_search.py
+++ b/tests/test_torch_angular_search.py
@@ -5,7 +5,10 @@ import platform
 import numpy as np
 import pytest
 
-from torch_so3.local_so3_sampling import get_local_high_resolution_angles
+from torch_so3.local_so3_sampling import (
+    get_local_high_resolution_angles,
+    get_roll_angles,
+)
 from torch_so3.uniform_so3_sampling import get_uniform_euler_angles
 
 # TODO: Check actual values of returned tensors
@@ -44,3 +47,12 @@ def test_get_local_high_resolution_angles():
     assert (local_angles[:, 1] <= 2.51).all()
     assert np.allclose(local_angles[:, 2].min().item(), -1.50)
     assert np.allclose(local_angles[:, 2].max().item(), 1.50)
+
+
+def test_get_roll_angles():
+    roll_angles = get_roll_angles()
+    assert roll_angles.shape == (151290, 3)
+
+    # range tests for angles
+    assert (roll_angles[:, 1] >= -10.01).all()
+    assert (roll_angles[:, 1] <= 10.01).all()

--- a/tests/test_torch_angular_search.py
+++ b/tests/test_torch_angular_search.py
@@ -35,12 +35,12 @@ def test_get_uniform_euler_angles_healpix():
 
 def test_get_local_high_resolution_angles():
     local_angles = get_local_high_resolution_angles()
-    assert local_angles.shape == (63333, 3)
+    assert local_angles.shape == (1581, 3)
 
     # range tests for angles
-    assert (local_angles[:, 0] >= 0.0).all()
-    assert (local_angles[:, 0] < 360.0).all()
-    assert (local_angles[:, 1] >= 0.0).all()
-    assert (local_angles[:, 1] <= 2.5).all()
-    assert np.allclose(local_angles[:, 2].min().item(), -1.5)
-    assert np.allclose(local_angles[:, 2].max().item(), 1.5)
+    assert (local_angles[:, 0] >= -1.51).all()
+    assert (local_angles[:, 0] <= 1.51).all()
+    assert (local_angles[:, 1] >= -2.51).all()
+    assert (local_angles[:, 1] <= 2.51).all()
+    assert np.allclose(local_angles[:, 2].min().item(), -1.50)
+    assert np.allclose(local_angles[:, 2].max().item(), 1.50)


### PR DESCRIPTION
In a two-rot-axis system with the rotation axis aligned with Z, allows you also so search over a roll axes that can be any (or search over all) axis orthogonal to the rotation axis.

Needs proper testing on real data before merging.
